### PR TITLE
Update README.md from latest changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,13 @@ The flask back-end REST APIs for the COA website.
 
 ## Getting Started
 
-1. Install python3.7 and pipenv.
+1. Install python3.7 and pipenv or have docker installed.
     - `sudo apt install python3.7`
     - `sudo python3.7 -m pip install pipenv`
+    - or
+    - `sudo apt install docker`
 2. Setup DB related environment variables (not posted here for security reasons).
-3. Clone down the project.
-4. Start server
+3. Start the server
     - `make run`
 
 ## Testing
@@ -23,4 +24,4 @@ use the curl command.
 
 Or to hit the deployed instance.
 
-- `curl http://coa-flask-app-dev.us-east-1.elasticbeanstalk.com/locations`
+- `curl http://coa-flask-app-prod.us-east-1.elasticbeanstalk.com/locations`


### PR DESCRIPTION
Two things changed:
 1. We couldn't get the python elastic beanstalk to work with the changes. This was for the better as swapping to a docker setup will be a lot easier. So we changed the name of the new env to prod not dev. This has been tested and is good to go whenever the front end is ready. Woot.
2. Added instructions for the docker setup.