### PR TITLE
Fix incorrect WHERE clause in event update endpoint

### DIFF
--- a/coa_flask_app/events.py
+++ b/coa_flask_app/events.py
@@ -150,7 +150,7 @@ def update(
                 trashbag_cnt = %s,
                 trash_weight = %s,
                 walking_distance = %s
-            WHERE item_id = %s
+            WHERE event_id = %s
             """
     with Accessor() as db_handle:
         db_handle.execute(


### PR DESCRIPTION
<!--
Please be patient, this is for the best. Do the checklist before filing an issue:
-->

- [x] Have you read the Contributing guide?
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
- [x] Have you formatted / linted your code locally prior to submission?
- [ ] Have you written tests for your code changes, as applicable?

## Problem this Solves
In the /events/update endpoint, the WHERE clause has a typo that references the item_id column as opposed to the event_id column.